### PR TITLE
[Internal]: Adding health check server to go proxy

### DIFF
--- a/_config/dev.yml
+++ b/_config/dev.yml
@@ -3,3 +3,4 @@ remoteWorkerConfig:
   fetchInterval: "60s"
 proxyConfig:
   port: "8080"
+  healthCheckPort: "8081"

--- a/_config/production.yml
+++ b/_config/production.yml
@@ -3,3 +3,4 @@ remoteWorkerConfig:
   fetchInterval: "60s"
 proxyConfig:
   port: "8080"
+  healthCheckPort: "8081"

--- a/_config/staging.yml
+++ b/_config/staging.yml
@@ -3,3 +3,4 @@ remoteWorkerConfig:
   fetchInterval: "60s"
 proxyConfig:
   port: "8080"
+  healthCheckPort: "8081"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -42,8 +42,10 @@ func run() error {
 
 			rcw := remoteconfigworker.New(cfg.RemoteWorkerConfig, &projectCache)
 			rp := proxy.New(proxy.ProxyOpts{
-				Port:    cfg.ProxyConfig.Port,
-				Handler: proxy.NewProxyHandler(&projectCache),
+				Port:               cfg.ProxyConfig.Port,
+				HealthCheckPort:    cfg.ProxyConfig.HealthCheckPort,
+				Handler:            proxy.NewProxyHandler(&projectCache),
+				HealthCheckHandler: proxy.NewHealthCheckHandler(),
 			})
 
 			err = rcw.Start(ctx)

--- a/config/config.go
+++ b/config/config.go
@@ -71,5 +71,12 @@ func resolveConfigWithEnv(config *Config) error {
 		}
 	}
 
+	if config.ProxyConfig.HealthCheckPort == "" {
+		config.ProxyConfig.HealthCheckPort = os.Getenv("HEALTH_CHECK_HTTP_PORT")
+		if config.ProxyConfig.HealthCheckPort == "" {
+			config.ProxyConfig.HealthCheckPort = "8081"
+		}
+	}
+
 	return nil
 }

--- a/proxy/health.go
+++ b/proxy/health.go
@@ -1,0 +1,12 @@
+package proxy
+
+import "net/http"
+
+func NewHealthCheckHandler() *http.ServeMux {
+	healthCheckHandler := http.NewServeMux()
+	healthCheckHandler.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	})
+	return healthCheckHandler
+}


### PR DESCRIPTION
Description:
- cloud run requires a health check endpoint to check for liveliness / readiness
- need to spin up a separate server since proxy server is just responsible for proxying all requests regardless of path