### PR TITLE
[Bug]: Remove headers before setting them

### DIFF
--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -49,9 +49,6 @@ func (p *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	director := func(req *http.Request) {
 		req.URL.Scheme = targetURL.Scheme
 		req.URL.Host = targetURL.Host
-		req.URL.Path = r.URL.Path
-		req.URL.RawQuery = r.URL.RawQuery
-		req.Header = r.Header
 		req.Host = targetURL.Host
 
 		req.Header.Del(SupergoodClientIDHeader)
@@ -62,6 +59,7 @@ func (p *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		for _, cred := range vendorConfig.Credentials {
+			req.Header.Del(cred.Key)
 			req.Header.Add(cred.Key, cred.Value)
 		}
 	}


### PR DESCRIPTION
Description:
- Remove headers before setting. An issue was observed proxying requests through openai's cloudflare instance. Cloudflare rejected calls that had multiple authorization headers set. 
- Remove director request updates that dont need to be updated